### PR TITLE
feat: Reset npm dependencies and install

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
 	"scripts": {
 		"build": "nuxt build",
 		"dev": "nuxt dev --dotenv .env.development",
+		"reset": "rm -rf ./node_modules && rm -rf package-lock.json && npm install",
 		"pgi": "npx nuxi dev --dotenv .env.pginfluencer --host",
 		"raffles": "npx nuxi dev --dotenv .env.raffles --host",
 		"fieldasorte": "npx nuxi dev --dotenv .env.fieldasorte --host",


### PR DESCRIPTION
This commit adds a new npm script called "reset" that removes the node_modules directory and package-lock.json file, and then reinstalls the dependencies using the "npm install" command. This can be used to reset the project dependencies to a clean state.