### PR TITLE
feat: Adicionar lógica de sorteios futuros e atualizar página de prêmios

### DIFF
--- a/stores/incentive.js
+++ b/stores/incentive.js
@@ -918,7 +918,7 @@ export const useStoreIncentive = defineStore('storeIncentive', {
 						winnerUser: draw.winnerUserId === this.inventory.userId,
 					});
 				});
-				
+
 				// Filtro para Prêmio ganhados pelo usuário
 				this.inventory.lotteryPrizesWon = this.gamification.lotteryDraws.listDrawsLatest.filter(
 					(draw) => draw.winnerUser
@@ -960,37 +960,44 @@ export const useStoreIncentive = defineStore('storeIncentive', {
 					}
 				);
 
+				// Caso exista uma lista com os próximos sorteios
+				if(data.lotteryDraws.length) {
+
 				// Lista de todos os próximos sorteios
-				data.lotteryDraws.forEach((draw) => {
-					this.gamification.lotteryDraws.listDrawsUpcoming.push({
-						id: draw.id,
-						name: draw.content.name,
-						description: draw.content.description,
-						fullDate: $formatDayMonthYearFull(draw.divulgationDate),
-						fullDateYearComplete: $formatDayMonthYearComplete(
-							draw.divulgationDate
-						),
-						date: draw.divulgationDate,
-						drawnNumber: this.luckyNumbers(
-							Array({ luckyNumber: String(draw.extractedDrawnNumber) })
-						),
-						image: draw.content.images.find((img) => img.subType === 'Splash')
-							.uri,
+					data.lotteryDraws.forEach((draw) => {
+						this.gamification.lotteryDraws.listDrawsUpcoming.push({
+							id: draw.id,
+							name: draw.content.name,
+							description: draw.content.description,
+							fullDate: $formatDayMonthYearFull(draw.divulgationDate),
+							fullDateYearComplete: $formatDayMonthYearComplete(
+								draw.divulgationDate
+							),
+							date: draw.divulgationDate,
+							drawnNumber: this.luckyNumbers(
+								Array({ luckyNumber: String(draw.extractedDrawnNumber) })
+							),
+							image: draw.content.images.find((img) => img.subType === 'Splash')
+								.uri,
+						});
 					});
-				});
 
-				// Obtendo um Objeto contendo as informações do próximo sorteio
-				const datesDraws = data.lotteryDraws.map(
-					(item) => item.divulgationDate
-				);
-				const mostRecentDate = $mostRecentDate(datesDraws, 'min');
+					// Obtendo um Objeto contendo as informações do próximo sorteio
+					const datesDraws = data.lotteryDraws.map(
+						(item) => item.divulgationDate
+					);
+					const mostRecentDate = $mostRecentDate(datesDraws, 'min');
 
-				if (this.gamification.lotteryDraws.listDrawsUpcoming.length) {
-					this.gamification.lotteryDraws.nextDraw =
-						this.gamification.lotteryDraws.listDrawsUpcoming.find(
-							(item) =>
-								item.fullDate === $formatDayMonthYearFull(mostRecentDate)
-						);
+					if (this.gamification.lotteryDraws.listDrawsUpcoming.length) {
+						this.gamification.lotteryDraws.nextDraw =
+							this.gamification.lotteryDraws.listDrawsUpcoming.find(
+								(item) =>
+									item.fullDate === $formatDayMonthYearFull(mostRecentDate)
+							);
+					}
+				} else { // caso contrário exibir apenas a informação do último sorteio realizado
+					this.gamification.lotteryDraws.listDrawsUpcoming.push(this.gamification.lotteryDraws.listDrawsLatest.slice().pop());
+					this.gamification.lotteryDraws.nextDraw = this.gamification.lotteryDraws.listDrawsLatest.slice().pop();
 				}
 
 				this.gamification.lotteryDraws.nextDraw.loading = true;
@@ -1155,7 +1162,7 @@ export const useStoreIncentive = defineStore('storeIncentive', {
 			if (!filter) {
 				return this.lotteryPrizesWonFilter;
 			}
-			
+
 			this.inventory.lotteryPrizesWonFilter =
 				this.inventory.lotteryPrizesWon.filter(
 					(item) => item.typePrize === filter


### PR DESCRIPTION
Este commit adiciona a lógica para exibir os próximos sorteios na página de prêmios. Também atualiza a página para exibir apenas o último sorteio realizado caso não haja sorteios futuros. As modificações incluem a adição de objetos de sorteio na lista de sorteios futuros, a obtenção da data mais recente dos sorteios e a atribuição do próximo sorteio. Além disso, o commit remove espaços em branco desnecessários no código.